### PR TITLE
Fix LLVMRevision source URL in cpt.py

### DIFF
--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -1354,7 +1354,7 @@ prefix = ''
 LLVM_GIT_URL = args['with_llvm_url']
 CLANG_GIT_URL = args['with_clang_url']
 CLING_GIT_URL = args['with_cling_url']
-LLVMRevision = urllib2.urlopen("https://raw.githubusercontent.com/ani07nov/cling/master/LastKnownGoodLLVMSVNRevision.txt").readline().strip()
+LLVMRevision = urllib2.urlopen("https://raw.githubusercontent.com/vgvassilev/cling/master/LastKnownGoodLLVMSVNRevision.txt").readline().strip()
 VERSION = ''
 REVISION = ''
 


### PR DESCRIPTION
LLVMRevision is being retrieved from an old URL, which contains the wrong LLVM revision. Update it to point at the current cling repository.
