### PR TITLE
Fix #51: Handle subprocess.CalledProcessError

### DIFF
--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -63,16 +63,30 @@ def _convert_subprocess_cmd(cmd):
     else:
         return [cmd]
 
+def _perror(e):
+    print("subprocess.CalledProcessError: Command '%s' returned non-zero exit status %s"%(' '.join(e.cmd), str(e.returncode)))
+    cleanup()
+    # Communicate return code to the calling program if any
+    sys.exit(e.returncode)
+
 def exec_subprocess_call(cmd, cwd):
     cmd = _convert_subprocess_cmd(cmd)
-    subprocess.check_call(cmd, cwd=cwd, shell=True,
-                          stdin=subprocess.PIPE, stdout=None, stderr=subprocess.STDOUT)
+    try:
+        subprocess.check_call(cmd, cwd=cwd, shell=True,
+                              stdin=subprocess.PIPE, stdout=None, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        _perror(e)
 
 def exec_subprocess_check_output(cmd, cwd):
     cmd = _convert_subprocess_cmd(cmd)
-    return subprocess.check_output(cmd, cwd=cwd, shell=True,
-                                    stdin=subprocess.PIPE, stderr=subprocess.STDOUT).decode('utf-8')
+    try:
+        out = subprocess.check_output(cmd, cwd=cwd, shell=True,
+                                      stdin=subprocess.PIPE, stderr=subprocess.STDOUT).decode('utf-8')
+    except subprocess.CalledProcessError as e:
+        _perror(e)
 
+    finally:
+        return out
 
 def box_draw_header():
     msg='cling (' + platform.machine() + ')' + formatdate(time.time(),tzinfo())


### PR DESCRIPTION
CPT will not pack binaries into packages which fail during build. Henceforth we should be skipping tests if we are to package binaries into bundles.

For example, we will need this in Windows to build NSIS installers:
`python2 cpt.py --current-dev=nsis --no-test`
or 
`python3 cpt.py --current-dev=nsis --no-test`

This patch is an extension of the `check_call` and `check_output` implemented by @nneonneo
