### PR TITLE
Fix MacOS 10.10 test failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,23 @@ language: cpp
 
 compiler:
   - gcc
+  - clang
+os:
+  - linux
+  - osx
 
 before_install:
   - echo $LANG
   - echo $LC_ALL
+  - clang --version || gcc --version
   - sudo apt-get install python-software-properties
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update
-  - sudo apt-get install gcc-4.8
-  - sudo apt-get install g++-4.8
+#  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+#  - sudo apt-get update
+#  - sudo apt-get install gcc-4.8
+#  - sudo apt-get install g++-4.8
   - sudo apt-get install binutils-gold
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+#  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+#  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 before_script:
   - mkdir src inst obj
@@ -50,7 +55,3 @@ notifications:
     #- "chat.freenode.net#rubinius"
   template:
     - "%{repository}/%{branch} (%{commit} - %{author}): %{message}"
-
-os:
-  - linux
-#  - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
 - echo $LC_ALL
 - clang --version || gcc --version
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; # GCC
-    sudo add-apt-repository -y ppa:h-rayflood/llvm; # Clang
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
+    sudo add-apt-repository -y ppa:h-rayflood/llvm;
     sudo apt-get update;
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,27 +8,17 @@ os:
 - linux
 - osx
 
+addons:
+  apt:
+    packages:
+      -g++-4.8
+      -gcc-4.8
+      -clang-3.4
+
 before_install:
 - echo $LANG
 - echo $LC_ALL
 - clang --version || gcc --version
-- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
-    sudo add-apt-repository -y ppa:h-rayflood/llvm;
-    sudo apt-get update;
-  fi
-
-install:
-- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    sudo apt-get install python-software-properties binutils-gold
-    if [ "$CXX" == "g++" ]; then
-      sudo apt-get install gcc-4.8 g++-4.8;
-      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50;
-      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50;
-    elif [ "$CXX" == "clang++" ]; then
-      sudo apt-get install --allow-unauthenticated -qq clang-3.4;
-    fi
-  fi
 
 before_script:
 - mkdir src inst obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 - echo $LANG
 - echo $LC_ALL
 - clang --version || gcc --version
-- if ["$TRAVIS_OS_NAME" == "linux" ]; then
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     if [ "$CXX" == "g++" ]; then
       export CXX=/usr/bin/g++-4.8;
       export CC=/usr/bin/gcc-4.8;

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ branches:
 
 notifications:
   recipients:
-    - vvasilev@cern.ch
+    - v.g.vassilev@gmail.com
     #- cling-dev@cern.ch
 
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,14 @@ cache:
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.6
     packages:
+      - binutils-gold
       - g++-4.9
       - gcc-4.9
-      - clang-3.4
+      - clang-3.6
 
 before_install:
 - echo $LANG

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,19 @@ addons:
       - llvm-toolchain-precise-3.6
     packages:
       - binutils-gold
-      - g++-4.7
-      - gcc-4.7
+      - g++-4.8
+      - gcc-4.8
       - clang-3.6
+    #alternatives: implemented 2 days ago and still to come.
 
 before_install:
 - echo $LANG
 - echo $LC_ALL
 - clang --version || gcc --version
 - if [ "$CXX" == "g++" ]; then
-    export CXX=/usr/bin/g++-4.7;
-    export CC=/usr/bin/gcc-4.7;
+    export CXX=/usr/bin/g++-4.8;
+    export CC=/usr/bin/gcc-4.8;
+    ls /usr/bin/g++-4.8
   elif [ "$CXX" == "clang++" ]; then
     export CXX=/usr/bin/clang++-3.6;
     export CC=/usr/bin/clang-3.6;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ addons:
       - llvm-toolchain-precise-3.6
     packages:
       - binutils-gold
-      - g++-4.9
-      - gcc-4.9
+      - g++-4.7
+      - gcc-4.7
       - clang-3.6
 
 before_install:
@@ -29,11 +29,11 @@ before_install:
 - echo $LC_ALL
 - clang --version || gcc --version
 - if [ "$CXX" == "g++" ]; then
-    export CXX=/usr/bin/g++4.9;
-    export CC=/usr/bin/gcc-4.9;
+    export CXX=/usr/bin/g++4.7;
+    export CC=/usr/bin/gcc-4.7;
   elif [ "$CXX" == "clang++" ]; then
-    export CXX=/usr/bin/clang++-3.5;
-    export CC=/usr/bin/clang-3.5;
+    export CXX=/usr/bin/clang++-3.6;
+    export CC=/usr/bin/clang-3.6;
   fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
       export CXX=/usr/bin/clang++-3.6;
       export CC=/usr/bin/clang-3.6;
     fi
+  fi
 
 before_script:
 - mkdir src inst obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
       export CC=/usr/bin/clang-3.6;
     fi
   fi
+- export
 
 before_script:
 - mkdir src inst obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,57 +1,59 @@
 language: cpp
 
 compiler:
-  - gcc
-  - clang
+- gcc
+- clang
+
 os:
-  - linux
-  - osx
+- linux
+- osx
 
 before_install:
-  - echo $LANG
-  - echo $LC_ALL
-  - clang --version || gcc --version
-  - sudo apt-get install python-software-properties
-#  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-#  - sudo apt-get update
-#  - sudo apt-get install gcc-4.8
-#  - sudo apt-get install g++-4.8
-  - sudo apt-get install binutils-gold
-#  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-#  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+- echo $LANG
+- echo $LC_ALL
+- echo clang --version || gcc --version
+- sudo apt-get install python-software-properties
+- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+- sudo apt-get update
+- sudo apt-get install binutils-gold
 
 before_script:
-  - mkdir src inst obj
-  - git clone https://github.com/vgvassilev/llvm.git src
-  - (cd src && git checkout cling-patches)
-  - git clone https://github.com/vgvassilev/clang.git src/tools/clang
-  - (cd src/tools/clang && git checkout cling-patches)
-  - git clone https://github.com/vgvassilev/cling.git src/tools/cling
-  - cd src
-  - cd ../obj
-  - travis_retry ../src/configure --prefix=`pwd`/../inst --disable-docs --disable-bindings --disable-visibility-inlines-hidden --disable-clang-rewriter --disable-clang-static-analyzer --disable-clang-arcmt --disable-compiler-version-checks --enable-targets=host
+- mkdir src inst obj
+- git clone https://github.com/vgvassilev/llvm.git src
+- (cd src && git checkout cling-patches)
+- git clone https://github.com/vgvassilev/clang.git src/tools/clang
+- (cd src/tools/clang && git checkout cling-patches)
+- git clone https://github.com/vgvassilev/cling.git src/tools/cling
+- cd src
+- cd ../obj
+- travis_retry ../src/configure --prefix=`pwd`/../inst --disable-docs --disable-bindings
+  --disable-visibility-inlines-hidden --disable-clang-rewriter --disable-clang-static-analyzer
+  --disable-clang-arcmt --disable-compiler-version-checks --enable-targets=host
 
 script:
-  - travis_retry make -j4 -k
-  - travis_retry make -j4 -k
-  - travis_retry make install
-  - cd tools/cling
-  - make test LIT_ARGS=--no-progress-bar
+- travis_retry make -j4 -k
+- travis_retry make -j4 -k
+- travis_retry make install
+- cd tools/cling
+- make test LIT_ARGS=--no-progress-bar
 
 branches:
   only:
-    - master
+  - master
 
 notifications:
   recipients:
-    - v.g.vassilev@gmail.com
-    #- cling-dev@cern.ch
-
+  - v.g.vassilev@gmail.com
   email:
     on_success: change
     on_failure: always
-  #irc:
-  #channels:
-    #- "chat.freenode.net#rubinius"
   template:
-    - "%{repository}/%{branch} (%{commit} - %{author}): %{message}"
+  - '%{repository}/%{branch} (%{commit} - %{author}): %{message}'
+
+deploy:
+  provider: releases
+  api_key:
+    secure: avhabhfxtmQ/WM3yJw8MbmfzIurOqf7Y+Wx+Xa6jwrHqrVn6UpvZiZ7An+3ieTv6ohDw6EjtbcvZizrnqDtnLlDqsFmlynC92raE5YU9DceK1cfNEflohQ0d+EVRRFQ6Y52YwPQbJ78kj26DAdHVSl+9n95VNGI3lEsIaYcNZWo=
+  file: ''
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,23 @@ before_install:
 - echo $LC_ALL
 - clang --version || gcc --version
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y &&
-    sudo apt-get update
+    # GCC
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
+    # Clang
+    sudo add-apt-repository -y ppa:h-rayflood/llvm;
+    sudo apt-get update;
   fi
 
 install:
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    sudo apt-get install python-software-properties binutils-gold gcc-4.8 g++-4.8
-  fi
-
-after_install:
-- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50 &&
-    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+    sudo apt-get install python-software-properties binutils-gold
+    if [ "$CXX" == "g++" ]; then
+      sudo apt-get install gcc-4.8 g++-4.8;
+      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50;
+      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50;
+    elif [ "$CXX" == "clang++" ]; then
+      sudo apt-get install --allow-unauthenticated -qq clang-3.4;
+    fi
   fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 - if [ "$CXX" == "g++" ]; then
     export CXX=/usr/bin/g++-4.8;
     export CC=/usr/bin/gcc-4.8;
-    ls /usr/bin/g++-4.8
+    ls /usr/bin/g++-4.8;
   elif [ "$CXX" == "clang++" ]; then
     export CXX=/usr/bin/clang++-3.6;
     export CC=/usr/bin/clang-3.6;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,14 @@ before_install:
 - echo $LANG
 - echo $LC_ALL
 - clang --version || gcc --version
-- if [ "$CXX" == "g++" ]; then
-    export CXX=/usr/bin/g++-4.8;
-    export CC=/usr/bin/gcc-4.8;
-    ls /usr/bin/g++-4.8;
-  elif [ "$CXX" == "clang++" ]; then
-    export CXX=/usr/bin/clang++-3.6;
-    export CC=/usr/bin/clang-3.6;
-  fi
+- if ["$TRAVIS_OS_NAME" == "linux" ]; then
+    if [ "$CXX" == "g++" ]; then
+      export CXX=/usr/bin/g++-4.8;
+      export CC=/usr/bin/gcc-4.8;
+    elif [ "$CXX" == "clang++" ]; then
+      export CXX=/usr/bin/clang++-3.6;
+      export CC=/usr/bin/clang-3.6;
+    fi
 
 before_script:
 - mkdir src inst obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ os:
 - linux
 - osx
 
+sudo: false
+
+cache:
+  apt: true
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: cpp
+# Force getting OSX
+language: objective-c
 
 compiler:
 - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ cache:
 addons:
   apt:
     packages:
-      - g++-4.8
-      - gcc-4.8
+      - g++-4.9
+      - gcc-4.9
       - clang-3.4
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,16 @@ os:
 before_install:
 - echo $LANG
 - echo $LC_ALL
-- echo clang --version || gcc --version
-- sudo apt-get install python-software-properties
-- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-- sudo apt-get update
-- sudo apt-get install binutils-gold
+- clang --version || gcc --version
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y &&
+    sudo apt-get update
+
+
+install:
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    sudo apt-get install python-software-properties &&
+    sudo apt-get install binutils-gold
 
 before_script:
 - mkdir src inst obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ before_install:
 - echo $LC_ALL
 - clang --version || gcc --version
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    # GCC
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
-    # Clang
-    sudo add-apt-repository -y ppa:h-rayflood/llvm;
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; # GCC
+    sudo add-apt-repository -y ppa:h-rayflood/llvm; # Clang
     sudo apt-get update;
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 - echo $LC_ALL
 - clang --version || gcc --version
 - if [ "$CXX" == "g++" ]; then
-    export CXX=/usr/bin/g++4.7;
+    export CXX=/usr/bin/g++-4.7;
     export CC=/usr/bin/gcc-4.7;
   elif [ "$CXX" == "clang++" ]; then
     export CXX=/usr/bin/clang++-3.6;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ cache:
 addons:
   apt:
     packages:
-      -g++-4.8
-      -gcc-4.8
-      -clang-3.4
+      - g++-4.8
+      - gcc-4.8
+      - clang-3.4
 
 before_install:
 - echo $LANG
@@ -48,7 +48,6 @@ script:
 branches:
   only:
   - master
-  - FixMacOS
 
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - compiler: gcc
       os: osx
 
-sudo: false
+sudo: true
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 - cd ../obj
 - travis_retry ../src/configure --prefix=`pwd`/../inst --disable-docs --disable-bindings
   --disable-visibility-inlines-hidden --disable-clang-rewriter --disable-clang-static-analyzer
-  --disable-clang-arcmt --disable-compiler-version-checks --enable-targets=host
+  --disable-clang-arcmt --disable-compiler-version-checks --enable-targets=host --enable-optimized=yes
 
 script:
 - travis_retry make -j4 -k

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,13 @@ before_install:
 - echo $LANG
 - echo $LC_ALL
 - clang --version || gcc --version
+- if [ "$CXX" == "g++" ]; then
+    export CXX=/usr/bin/g++4.9;
+    export CC=/usr/bin/gcc-4.9;
+  elif [ "$CXX" == "clang++" ]; then
+    export CXX=/usr/bin/clang++-3.5;
+    export CC=/usr/bin/clang-3.5;
+  fi
 
 before_script:
 - mkdir src inst obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# Force getting OSX
-language: objective-c
+language: cpp
 
 compiler:
 - gcc
@@ -20,8 +19,12 @@ before_install:
 
 install:
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    sudo apt-get install python-software-properties &&
-    sudo apt-get install binutils-gold
+    sudo apt-get install python-software-properties binutils-gold gcc-4.8 g++-4.8
+
+after_install:
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50 &&
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 before_script:
 - mkdir src inst obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ script:
 branches:
   only:
   - master
+  - FixMacOS
 
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,18 @@ before_install:
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y &&
     sudo apt-get update
-
+  fi
 
 install:
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     sudo apt-get install python-software-properties binutils-gold gcc-4.8 g++-4.8
+  fi
 
 after_install:
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50 &&
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+  fi
 
 before_script:
 - mkdir src inst obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ os:
 - linux
 - osx
 
+matrix:
+  exclude:
+    - compiler: gcc
+      os: osx
+
 sudo: false
 
 cache:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -57,12 +57,15 @@ if cling_obj_root is not None:
     if not llvm_tools_dir:
         lit_config.fatal('No LLVM tools dir set!')
     path = os.path.pathsep.join((llvm_tools_dir, config.environment['PATH']))
-    # For MacOS with libc++, out clang will not find libc++ causing errors with
+
+    # For MacOS with libc++, our clang will not find libc++ causing errors with
     # STL. Use the XCode one instead by not adding ours to the path. Cling is
     # still found through deferCling().
-    if platform.mac_ver()[0] is '' or \
-      float('.'.join(platform.mac_ver()[0].split('.')[:2])) < 10.9:
-        config.environment['PATH'] = path
+    # Avoid adding our *+Asserts/bin folder to the path because, it will resolve
+    # to the clang binary residing there, causing the havoc described above.
+    #if platform.mac_ver()[0] is '' or \
+    #  float('.'.join(platform.mac_ver()[0].split('.')[:2])) < 10.9:
+    #    config.environment['PATH'] = path
 
     llvm_libs_dir = getattr(config, 'llvm_libs_dir', None)
     if not llvm_libs_dir:


### PR DESCRIPTION
In order to find the right system include paths cling calls the system compiler.
When cling is run as a part of the testsuite, LIT injects the path to the
cling binary (*+Asserts/bin). There resides also clang++ (built as a byproduct
of cling's build). In this case cling resolves the newly built clang++,
which is without MacOS extensions and which is not able to tell us the
include paths.

So on MacOS do not add the (*+Asserts/bin) to the PATH variable.