### PR TITLE
New temporary directory for TMPDIR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 - if [ "$CXX" == "g++" ]; then
     export CXX=/usr/bin/g++-4.8;
     export CC=/usr/bin/gcc-4.8;
-    ls /usr/bin/g++-4.8
+    ls /usr/bin/g++-4.8;
   elif [ "$CXX" == "clang++" ]; then
     export CXX=/usr/bin/clang++-3.6;
     export CC=/usr/bin/clang-3.6;

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ before_install:
 
 before_script:
 - mkdir src inst obj
+- mkdir -v $TRAVIS_BUILD_DIR/tmp
+- ls -l
 - git clone https://github.com/vgvassilev/llvm.git src
 - (cd src && git checkout cling-patches)
 - git clone https://github.com/vgvassilev/clang.git src/tools/clang


### PR DESCRIPTION
```/tmp``` is used for ```tmpfs```, which might be the reason why we are seeing ```No space left on device``` errors. I suspect there is not much space outside the Travis working directory. I want to see if this change helps. Do not merge it in ```master``` branch, since the change is not permanent.

The patch creates a new temporary location where all temporary files created during the build process will go. The variable ```$TMPDIR``` has not been set in the ```.travis.yml``` as it is done in the Travis CI settings.