### PR TITLE
CPT patches

### DIFF
--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -1279,9 +1279,9 @@ parser.add_argument('--nsis-tag', help='Package the snapshot of a given tag in a
 parser.add_argument('--dmg-tag', help='Package the snapshot of a given tag in a DMG package (.dmg)')
 
 # Variable overrides
-parser.add_argument('--with-llvm-url', action='store', help='Specify an alternate URL of LLVM repo', default='http://root.cern.ch/git/llvm.git')
-parser.add_argument('--with-clang-url', action='store', help='Specify an alternate URL of Clang repo', default='http://root.cern.ch/git/clang.git')
-parser.add_argument('--with-cling-url', action='store', help='Specify an alternate URL of Cling repo', default='http://root.cern.ch/git/cling.git')
+parser.add_argument('--with-llvm-url', action='store', help='Specify an alternate URL of LLVM repo', default='https://github.com/vgvassilev/llvm.git')
+parser.add_argument('--with-clang-url', action='store', help='Specify an alternate URL of Clang repo', default='https://github.com/vgvassilev/clang.git')
+parser.add_argument('--with-cling-url', action='store', help='Specify an alternate URL of Cling repo', default='https://github.com/vgvassilev/cling.git')
 
 parser.add_argument('--no-test', help='Do not run test suite of Cling', action='store_true')
 parser.add_argument('--create-dev-env', help='Set up a release/debug environment')

--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -138,9 +138,11 @@ def wget(url, out_dir):
         else:
             # Python 3.x
             file_size = int(u.getheader("Content-Length"))
-    except IndexError, e:
-        print(e)
-        print('  Error due to broken pipe. Retrying ...')
+    except (IndexError, TypeError) as e:
+        # IndexError is generated in Python 2
+        # TypeError is generated in Python 3
+        print('  Error due to broken pipe: ', e)
+        print('  Retrying ...')
         wget(url, out_dir)
 
     else:


### PR DESCRIPTION
Fetches the ```cling-patches``` branch of LLVM and Clang as tarballs, since ```git clone``` occupies a lot of space (also requires more downloading) and we don't need the local copy to be a git repository.