### PR TITLE
Add generic overload to setValueNoAlloc

### DIFF
--- a/lib/Interpreter/ValueExtractionSynthesizer.cpp
+++ b/lib/Interpreter/ValueExtractionSynthesizer.cpp
@@ -504,6 +504,10 @@ namespace runtime {
         .getAs<unsigned long long>() = value;
       dumpIfNoStorage(vpSVR, vpOn);
     }
+    template <class T>
+    void setValueNoAlloc(void* vpI, void* vpSVR, void* vpQT, char, T) {
+      allocateStoredRefValueAndGetGV(vpI, vpSVR, vpQT);
+    }
     void setValueNoAlloc(void* vpI, void* vpSVR, void* vpQT, char vpOn,
                          const void* value){
       allocateStoredRefValueAndGetGV(vpI, vpSVR, vpQT).getAs<void*>()


### PR DESCRIPTION
(This is more of a bug report).

Without such an overload, calling `MetaProcessor::process` with a non nullptr value sometimes causes compilation error in the interpreted code, namely  `No matching function for call to setValueNoAlloc`.

It seems to only happen for certain types, and not others. I am working on putting together a minimal example.