### PR TITLE
Fix cpt.py a careless mistake

### DIFF
--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -1715,7 +1715,7 @@ def custom_input(prompt, always_yes=False):
     if always_yes:
         return 'y'
     else:
-        input(prompt)
+        return input(prompt)
 
 ###############################################################################
 #                           Platform initialization                           #


### PR DESCRIPTION
When I attempted to run the cling package tool (cpt.py), use the command:
```bash
./cpt.py --check-requirements && ./cpt.py --create-dev-env Debug --with-workdir=./cling-build/
```
I submitted `yes` to the prompt and then encountered an exception(NoneType).
After checked the code,I found the problem is missing a `return` keyword in `custom_input()`.

Thanks for your code, It helped me a lot! :smile: 


