### PR TITLE
Default pkg flag to create tar

### DIFF
--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -2023,11 +2023,20 @@ if args['current_dev']:
             test_cling()
         make_dmg()
         cleanup()
+
     elif args['current_dev'].startswith('branch'):
         compile(os.path.join(workdir, 'cling-' + VERSION.replace('-' + REVISION[:7], '')), libcpp)
         #install_prefix()
         if not args['no_test']:
             test_cling()
+        cleanup()
+
+    elif args['current_dev'] == 'pkg':
+        compile(os.path.join(workdir, 'cling-' + DIST + '-' + REV + '-' + platform.machine().lower() + '-' + VERSION), libcpp)
+        install_prefix()
+        if not args['no_test']:
+            test_cling()
+        tarball()
         cleanup()
 
 if args['last_stable']:
@@ -2107,6 +2116,15 @@ if args['last_stable']:
         if not args['no_test']:
             test_cling()
         make_dmg()
+        cleanup()
+
+    elif args['last_stable'] == 'pkg':
+        set_version()
+        compile(os.path.join(workdir, 'cling-' + DIST + '-' + REV + '-' + platform.machine().lower() + '-' + VERSION), libcpp)
+        install_prefix()
+        if not args['no_test']:
+            test_cling()
+        tarball()
         cleanup()
 
 if args['tarball_tag']:


### PR DESCRIPTION
For non [Windows, Ubuntu, Redhat, OS X] operating systems the pkg flag to the --last stable and --current-dev arguments didn't do anything - It should create a tar because that is the default behaviour for Unix like platforms which support bash.