### PR TITLE
Fix brew cask uninstall oclint failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
       env: COMPILER=g++-7 CCOMPILER=gcc-7
       osx_image: xcode8.3
       before_install:
-        - brew cask uninstall oclint
+        - if brew cask info oclint | grep "oclint" >/dev/null 2>&1; then :; else brew cask uninstall oclint; fi
         - brew install gcc@7
       compiler: gcc-7
 


### PR DESCRIPTION
Travis would crash at `brew cask uninstall oclint` if oclint was already
uninstalled - this fixes it.