### PR TITLE
Add more cppyy interfaces to libInterOp

### DIFF
--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -43,6 +43,8 @@ namespace InterOp {
   TCppScope_t GetGlobalScope(TCppSema_t sema);
 
   TCppScope_t GetScope(TCppSema_t sema, const std::string &name, TCppScope_t parent);
+
+  TCppScope_t GetScopeFromCompleteName(TCppSema_t sema, const std::string &name);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -68,6 +68,11 @@ namespace InterOp {
   TCppIndex_t GetFunctionNumArgs(TCppFunction_t func);
 
   TCppIndex_t GetFunctionRequiredArgs(TCppFunction_t func);
+
+  std::string GetFunctionSignature(
+          TCppFunction_t func,
+          bool show_formal_args = false,
+          TCppIndex_t max_args = -1);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -18,6 +18,7 @@ namespace InterOp {
   using TCppIndex_t = size_t;
   using TCppScope_t = void*;
   using TCppType_t = void*;
+  using TCppFunction_t = void*;
   using TCppSema_t = void*;
 
   bool IsNamespace(TCppScope_t scope);
@@ -56,6 +57,8 @@ namespace InterOp {
   TCppScope_t GetBaseClass(TCppType_t klass, TCppIndex_t ibase);
 
   bool IsSubclass(TCppScope_t derived, TCppScope_t base);
+
+  std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -49,6 +49,8 @@ namespace InterOp {
   TCppScope_t GetNamed(TCppSema_t sema, const std::string &name, TCppScope_t parent);
 
   TCppScope_t GetParentScope(TCppScope_t scope);
+
+  TCppScope_t GetScopeFromType(TCppType_t type);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -99,6 +99,8 @@ namespace InterOp {
   std::string GetVariableTypeAsString(TCppScope_t var);
 
   intptr_t GetVariableOffset(TInterp_t interp, TCppScope_t var);
+
+  bool IsPublicVariable(TCppScope_t var);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -84,6 +84,8 @@ namespace InterOp {
   bool IsPublicMethod(TCppFunction_t method);
 
   bool IsProtectedMethod(TCppFunction_t method);
+
+  bool IsPrivateMethod(TCppFunction_t method);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -107,6 +107,8 @@ namespace InterOp {
   bool IsPrivateVariable(TCppScope_t var);
 
   bool IsStaticVariable(TCppScope_t var);
+
+  bool IsConstVariable(TCppScope_t var);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -11,6 +11,7 @@
 #define CLING_INTERPRETER_INTEROP_H
 
 #include <string>
+#include <vector>
 
 namespace cling {
 namespace InterOp {

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -15,6 +15,7 @@
 
 namespace cling {
 namespace InterOp {
+  using TCppIndex_t = size_t;
   using TCppScope_t = void*;
   using TCppType_t = void*;
   using TCppSema_t = void*;
@@ -51,6 +52,8 @@ namespace InterOp {
   TCppScope_t GetParentScope(TCppScope_t scope);
 
   TCppScope_t GetScopeFromType(TCppType_t type);
+
+  TCppScope_t GetBaseClass(TCppType_t klass, TCppIndex_t ibase);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -41,6 +41,8 @@ namespace InterOp {
   std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope);
 
   TCppScope_t GetGlobalScope(TCppSema_t sema);
+
+  TCppScope_t GetScope(TCppSema_t sema, const std::string &name, TCppScope_t parent);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -77,6 +77,9 @@ namespace InterOp {
   std::string GetFunctionPrototype(TCppFunction_t func, bool show_formal_args = false);
 
   bool IsTemplatedFunction(TCppFunction_t func);
+
+  bool ExistsFunctionTemplate(TCppSema_t sema, const std::string& name,
+          TCppScope_t parent = 0);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -101,6 +101,8 @@ namespace InterOp {
   intptr_t GetVariableOffset(TInterp_t interp, TCppScope_t var);
 
   bool IsPublicVariable(TCppScope_t var);
+
+  bool IsProtectedVariable(TCppScope_t var);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -64,6 +64,8 @@ namespace InterOp {
         TCppSema_t sema, TCppScope_t scope, const std::string& name);
 
   std::string GetFunctionReturnTypeAsString(TCppFunction_t func);
+
+  TCppIndex_t GetFunctionNumArgs(TCppFunction_t func);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -47,6 +47,8 @@ namespace InterOp {
   TCppScope_t GetScopeFromCompleteName(TCppSema_t sema, const std::string &name);
 
   TCppScope_t GetNamed(TCppSema_t sema, const std::string &name, TCppScope_t parent);
+
+  TCppScope_t GetParentScope(TCppScope_t scope);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -86,6 +86,8 @@ namespace InterOp {
   bool IsProtectedMethod(TCppFunction_t method);
 
   bool IsPrivateMethod(TCppFunction_t method);
+
+  bool IsConstructor(TCppFunction_t method);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -75,6 +75,8 @@ namespace InterOp {
           TCppIndex_t max_args = -1);
 
   std::string GetFunctionPrototype(TCppFunction_t func, bool show_formal_args = false);
+
+  bool IsTemplatedFunction(TCppFunction_t func);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -105,6 +105,8 @@ namespace InterOp {
   bool IsProtectedVariable(TCppScope_t var);
 
   bool IsPrivateVariable(TCppScope_t var);
+
+  bool IsStaticVariable(TCppScope_t var);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -62,6 +62,8 @@ namespace InterOp {
 
   std::vector<TCppFunction_t> GetFunctionsUsingName(
         TCppSema_t sema, TCppScope_t scope, const std::string& name);
+
+  std::string GetFunctionReturnTypeAsString(TCppFunction_t func);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -17,6 +17,7 @@ namespace cling {
 namespace InterOp {
   using TCppScope_t = void*;
   using TCppType_t = void*;
+  using TCppSema_t = void*;
 
   bool IsNamespace(TCppScope_t scope);
   // See TClingClassInfo::IsLoaded
@@ -39,6 +40,7 @@ namespace InterOp {
 
   std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope);
 
+  TCppScope_t GetGlobalScope(TCppSema_t sema);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -66,6 +66,8 @@ namespace InterOp {
   std::string GetFunctionReturnTypeAsString(TCppFunction_t func);
 
   TCppIndex_t GetFunctionNumArgs(TCppFunction_t func);
+
+  TCppIndex_t GetFunctionRequiredArgs(TCppFunction_t func);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -94,6 +94,8 @@ namespace InterOp {
   bool IsStaticMethod(TCppFunction_t method);
 
   std::vector<TCppScope_t> GetDatamembers(TCppScope_t scope);
+
+  std::string GetVariableTypeAsString(TCppScope_t var);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -90,6 +90,8 @@ namespace InterOp {
   bool IsConstructor(TCppFunction_t method);
 
   bool IsDestructor(TCppFunction_t method);
+
+  bool IsStaticMethod(TCppFunction_t method);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -59,6 +59,9 @@ namespace InterOp {
   bool IsSubclass(TCppScope_t derived, TCppScope_t base);
 
   std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass);
+
+  std::vector<TCppFunction_t> GetFunctionsUsingName(
+        TCppSema_t sema, TCppScope_t scope, const std::string& name);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -88,6 +88,8 @@ namespace InterOp {
   bool IsPrivateMethod(TCppFunction_t method);
 
   bool IsConstructor(TCppFunction_t method);
+
+  bool IsDestructor(TCppFunction_t method);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -82,6 +82,8 @@ namespace InterOp {
           TCppScope_t parent = 0);
 
   bool IsPublicMethod(TCppFunction_t method);
+
+  bool IsProtectedMethod(TCppFunction_t method);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -45,6 +45,8 @@ namespace InterOp {
   TCppScope_t GetScope(TCppSema_t sema, const std::string &name, TCppScope_t parent);
 
   TCppScope_t GetScopeFromCompleteName(TCppSema_t sema, const std::string &name);
+
+  TCppScope_t GetNamed(TCppSema_t sema, const std::string &name, TCppScope_t parent);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -80,6 +80,8 @@ namespace InterOp {
 
   bool ExistsFunctionTemplate(TCppSema_t sema, const std::string& name,
           TCppScope_t parent = 0);
+
+  bool IsPublicMethod(TCppFunction_t method);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -54,6 +54,8 @@ namespace InterOp {
   TCppScope_t GetScopeFromType(TCppType_t type);
 
   TCppScope_t GetBaseClass(TCppType_t klass, TCppIndex_t ibase);
+
+  bool IsSubclass(TCppScope_t derived, TCppScope_t base);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -20,6 +20,7 @@ namespace InterOp {
   using TCppType_t = void*;
   using TCppFunction_t = void*;
   using TCppSema_t = void*;
+  using TInterp_t = void*;
 
   bool IsNamespace(TCppScope_t scope);
   // See TClingClassInfo::IsLoaded
@@ -96,6 +97,8 @@ namespace InterOp {
   std::vector<TCppScope_t> GetDatamembers(TCppScope_t scope);
 
   std::string GetVariableTypeAsString(TCppScope_t var);
+
+  intptr_t GetVariableOffset(TInterp_t interp, TCppScope_t var);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -103,6 +103,8 @@ namespace InterOp {
   bool IsPublicVariable(TCppScope_t var);
 
   bool IsProtectedVariable(TCppScope_t var);
+
+  bool IsPrivateVariable(TCppScope_t var);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -73,6 +73,8 @@ namespace InterOp {
           TCppFunction_t func,
           bool show_formal_args = false,
           TCppIndex_t max_args = -1);
+
+  std::string GetFunctionPrototype(TCppFunction_t func, bool show_formal_args = false);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -92,6 +92,8 @@ namespace InterOp {
   bool IsDestructor(TCppFunction_t method);
 
   bool IsStaticMethod(TCppFunction_t method);
+
+  std::vector<TCppScope_t> GetDatamembers(TCppScope_t scope);
 } // end namespace InterOp
 
 } // end namespace cling

--- a/include/cling/Interpreter/InterOp.h
+++ b/include/cling/Interpreter/InterOp.h
@@ -34,6 +34,8 @@ namespace InterOp {
 
   std::string GetName(TCppType_t klass);
 
+  std::string GetCompleteName(TCppType_t klass);
+
   std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope);
 
 } // end namespace InterOp

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -262,6 +262,38 @@ namespace InterOp {
     }
     return {};
   }
+
+  std::vector<TCppFunction_t> GetFunctionsUsingName(
+        TCppSema_t sema, TCppScope_t scope, const std::string& name)
+  {
+    auto *D = (Decl *) scope;
+    std::vector<TCppFunction_t> funcs;
+    llvm::StringRef Name(name);
+    auto *S = (Sema *) sema;
+    DeclarationName DName = &S->Context.Idents.get(name);
+    clang::LookupResult R(*S,
+                          DName,
+                          SourceLocation(),
+                          Sema::LookupOrdinaryName,
+                          Sema::ForVisibleRedeclaration);
+
+    cling::utils::Lookup::Named(S, R, Decl::castToDeclContext(D));
+
+    if (R.empty())
+      return funcs;
+
+    R.resolveKind();
+
+    for (LookupResult::iterator Res = R.begin(), ResEnd = R.end();
+         Res != ResEnd;
+         ++Res) {
+      if (llvm::isa<FunctionDecl>(*Res)) {
+        funcs.push_back((TCppFunction_t) *Res);
+      }
+    }
+
+    return funcs;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -210,6 +210,23 @@ namespace InterOp {
 
     return 0;
   }
+
+  TCppScope_t GetBaseClass(TCppScope_t klass, TCppIndex_t ibase)
+  {
+    auto *D = (Decl *) klass;
+    auto *CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D);
+    if (!CXXRD || CXXRD->getNumBases() <= ibase) return 0;
+
+    auto type = (CXXRD->bases_begin() + ibase)->getType();
+    if (auto RT = llvm::dyn_cast<RecordType>(type)) {
+      return (TCppScope_t) RT->getDecl()->getCanonicalDecl();
+    } else if (auto TST = llvm::dyn_cast<clang::TemplateSpecializationType>(type)) {
+      return (TCppScope_t) TST->getTemplateName()
+          .getAsTemplateDecl()->getCanonicalDecl();
+    }
+
+    return 0;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -549,6 +549,11 @@ namespace InterOp {
   {
     return CheckVariableAccess(var, AccessSpecifier::AS_public);
   }
+
+  bool IsProtectedVariable(TCppScope_t var)
+  {
+    return CheckVariableAccess(var, AccessSpecifier::AS_protected);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -294,6 +294,15 @@ namespace InterOp {
 
     return funcs;
   }
+
+  std::string GetFunctionReturnTypeAsString(TCppFunction_t func)
+  {
+    auto *D = (clang::Decl *) func;
+    if (auto *FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
+        return FD->getReturnType().getAsString();
+    }
+    return "";
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -559,6 +559,16 @@ namespace InterOp {
   {
     return CheckVariableAccess(var, AccessSpecifier::AS_private);
   }
+
+  bool IsStaticVariable(TCppScope_t var)
+  {
+    auto *D = (Decl *) var;
+    if (llvm::isa_and_nonnull<VarDecl>(D)) {
+      return true;
+    }
+
+    return false;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -445,6 +445,12 @@ namespace InterOp {
   {
     return CheckMethodAccess(method, AccessSpecifier::AS_private);
   }
+
+  bool IsConstructor(TCppFunction_t method)
+  {
+    auto *D = (Decl *) method;
+    return llvm::isa_and_nonnull<CXXConstructorDecl>(D);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -383,6 +383,25 @@ namespace InterOp {
     }
     return "<unknown>";
   }
+
+  bool IsTemplatedFunction(TCppFunction_t func)
+  {
+    auto *D = (Decl *) func;
+    if (llvm::isa_and_nonnull<FunctionTemplateDecl>(D)) {
+      return true;
+    }
+
+    if (auto *FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
+      auto TK = FD->getTemplatedKind();
+      return TK == FunctionDecl::TemplatedKind::
+                   TK_FunctionTemplateSpecialization
+            || TK == FunctionDecl::TemplatedKind::
+                     TK_DependentFunctionTemplateSpecialization
+            || TK == FunctionDecl::TemplatedKind::TK_FunctionTemplate;
+    }
+
+    return false;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -166,6 +166,23 @@ namespace InterOp {
     }
     return GetScope(S, name.substr(start, end), curr_scope);
   }
+
+  TCppScope_t GetNamed(TCppSema_t sema, const std::string &name, TCppScope_t parent)
+  {
+    clang::DeclContext *Within = 0;
+    if (parent) {
+      auto *D = (clang::Decl *)parent;
+      Within = llvm::dyn_cast<clang::DeclContext>(D);
+    }
+
+    auto *S = (Sema *) sema;
+    auto *ND = cling::utils::Lookup::Named(S, name, Within);
+    if (ND && ND != (clang::NamedDecl*) -1) {
+      return (TCppScope_t)(ND->getCanonicalDecl());
+    }
+
+    return 0;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -183,6 +183,22 @@ namespace InterOp {
 
     return 0;
   }
+
+  TCppScope_t GetParentScope(TCppScope_t scope)
+  {
+    auto *D = (clang::Decl *) scope;
+
+    if (llvm::isa_and_nonnull<TranslationUnitDecl>(D)) {
+      return 0;
+    }
+    auto *ParentDC = D->getDeclContext();
+
+    if (!ParentDC)
+      return 0;
+
+    return (TCppScope_t) clang::Decl::castFromDeclContext(
+            ParentDC)->getCanonicalDecl();
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -484,6 +484,17 @@ namespace InterOp {
 
     return {};
   }
+
+  std::string GetVariableTypeAsString(TCppScope_t var)
+  {
+    auto D = (Decl *) var;
+
+    if (auto DD = llvm::dyn_cast_or_null<DeclaratorDecl>(D)) {
+        return DD->getType().getAsString();
+    }
+
+    return "";
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/Sema/Sema.h"
+#include "clang/Sema/Lookup.h"
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
@@ -120,6 +121,12 @@ namespace InterOp {
     }
 
     return {};
+  }
+
+  TCppScope_t GetGlobalScope(TCppSema_t sema)
+  {
+    auto *S = (Sema *) sema;
+    return S->getASTContext().getTranslationUnitDecl();
   }
 } // end namespace InterOp
 

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -467,6 +467,23 @@ namespace InterOp {
 
     return false;
   }
+
+  std::vector<TCppScope_t> GetDatamembers(TCppScope_t scope)
+  {
+    auto *D = (Decl *) scope;
+
+    if (auto *CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
+      std::vector<TCppScope_t> datamembers;
+      for (auto it = CXXRD->field_begin(), end = CXXRD->field_end();
+              it != end ; it++) {
+        datamembers.push_back((TCppScope_t) *it);
+      }
+
+      return datamembers;
+    }
+
+    return {};
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -420,6 +420,21 @@ namespace InterOp {
 
     return true;
   }
+
+  bool CheckMethodAccess(TCppFunction_t method, AccessSpecifier AS)
+  {
+    auto *D = (Decl *) method;
+    if (auto *CXXMD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)) {
+      return CXXMD->getAccess() == AS;
+    }
+
+    return false;
+  }
+
+  bool IsPublicMethod(TCppFunction_t method)
+  {
+    return CheckMethodAccess(method, AccessSpecifier::AS_public);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -451,6 +451,12 @@ namespace InterOp {
     auto *D = (Decl *) method;
     return llvm::isa_and_nonnull<CXXConstructorDecl>(D);
   }
+
+  bool IsDestructor(TCppFunction_t method)
+  {
+    auto *D = (Decl *) method;
+    return llvm::isa_and_nonnull<CXXDestructorDecl>(D);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -303,6 +303,15 @@ namespace InterOp {
     }
     return "";
   }
+
+  TCppIndex_t GetFunctionNumArgs(TCppFunction_t func)
+  {
+    auto *D = (clang::Decl *) func;
+    if (auto *FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
+      return FD->getNumParams();
+    }
+    return 0;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -94,6 +94,20 @@ namespace InterOp {
     return D->getNameAsString();
   }
 
+  std::string GetCompleteName(TCppType_t klass)
+  {
+    auto *D = (Decl *) klass;
+    if (auto *ND = llvm::dyn_cast_or_null<NamedDecl>(D)) {
+      return ND->getQualifiedNameAsString();
+    }
+
+    if (llvm::isa_and_nonnull<TranslationUnitDecl>(D)) {
+      return "";
+    }
+
+    return "<unnamed>";
+  }
+
   std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope) {
     auto *D = (clang::Decl *) scope;
 

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -368,6 +368,21 @@ namespace InterOp {
     }
     return "<unknown>";
   }
+
+  std::string GetFunctionPrototype(TCppFunction_t func, bool show_formal_args)
+  {
+    auto *D = (clang::Decl *) func;
+    if (auto *FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
+      std::stringstream proto;
+
+      proto << FD->getReturnType().getAsString()
+            << (FD->getReturnType()->isPointerType() ? "" : " ");
+      proto << FD->getQualifiedNameAsString();
+      get_function_params(proto, FD, show_formal_args);
+      return proto.str();
+    }
+    return "<unknown>";
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -402,6 +402,24 @@ namespace InterOp {
 
     return false;
   }
+
+  bool ExistsFunctionTemplate(TCppSema_t sema, const std::string& name,
+          TCppScope_t parent)
+  {
+    DeclContext *Within = 0;
+    if (parent) {
+      auto *D = (Decl *)parent;
+      Within = llvm::dyn_cast<DeclContext>(D);
+    }
+
+    auto *S = (Sema *) sema;
+    auto *ND = cling::utils::Lookup::Named(S, name, Within);
+
+    if (!ND)
+      return false;
+
+    return true;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -435,6 +435,11 @@ namespace InterOp {
   {
     return CheckMethodAccess(method, AccessSpecifier::AS_public);
   }
+
+  bool IsProtectedMethod(TCppFunction_t method)
+  {
+    return CheckMethodAccess(method, AccessSpecifier::AS_protected);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -457,6 +457,16 @@ namespace InterOp {
     auto *D = (Decl *) method;
     return llvm::isa_and_nonnull<CXXDestructorDecl>(D);
   }
+
+  bool IsStaticMethod(TCppFunction_t method)
+  {
+    auto *D = (Decl *) method;
+    if (auto *CXXMD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)) {
+      return CXXMD->isStatic();
+    }
+
+    return false;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -150,6 +150,22 @@ namespace InterOp {
 
     return 0;
   }
+
+  TCppScope_t GetScopeFromCompleteName(TCppSema_t sema, const std::string &name)
+  {
+    std::string delim = "::";
+    size_t start = 0;
+    size_t end = name.find(delim);
+    TCppScope_t curr_scope = 0;
+    auto *S = (Sema *) sema;
+    while (end != std::string::npos)
+    {
+      curr_scope = GetScope(S, name.substr(start, end - start), curr_scope);
+      start = end + delim.length();
+      end = name.find(delim, start);
+    }
+    return GetScope(S, name.substr(start, end), curr_scope);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -227,6 +227,26 @@ namespace InterOp {
 
     return 0;
   }
+
+  bool IsSubclass(TCppScope_t derived, TCppScope_t base)
+  {
+    if (derived == base)
+      return true;
+
+    auto *derived_D = (clang::Decl *) derived;
+    auto *base_D = (clang::Decl *) base;
+
+    if (!derived_D ||
+        !base_D    ||
+        llvm::isa<TranslationUnitDecl>(derived_D) ||
+        llvm::isa<TranslationUnitDecl>(base_D))
+        return false;
+
+    if (auto derived_CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(derived_D))
+      if (auto base_CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(base_D))
+        return derived_CXXRD->isDerivedFrom(base_CXXRD);
+    return false;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -554,6 +554,11 @@ namespace InterOp {
   {
     return CheckVariableAccess(var, AccessSpecifier::AS_protected);
   }
+
+  bool IsPrivateVariable(TCppScope_t var)
+  {
+    return CheckVariableAccess(var, AccessSpecifier::AS_private);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -199,6 +199,17 @@ namespace InterOp {
     return (TCppScope_t) clang::Decl::castFromDeclContext(
             ParentDC)->getCanonicalDecl();
   }
+
+  TCppScope_t GetScopeFromType(TCppType_t type)
+  {
+    if (!type) return 0;
+
+    auto *QT = (clang::QualType *) type;
+    if (auto *RD = QT->getTypePtr()->getAsRecordDecl())
+      return (TCppScope_t) (RD->getCanonicalDecl());
+
+    return 0;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -312,6 +312,15 @@ namespace InterOp {
     }
     return 0;
   }
+
+  TCppIndex_t GetFunctionRequiredArgs(TCppFunction_t func)
+  {
+    auto *D = (clang::Decl *) func;
+    if (auto *FD = llvm::dyn_cast_or_null<FunctionDecl> (D)) {
+      return FD->getMinRequiredArguments();
+    }
+    return 0;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -440,6 +440,11 @@ namespace InterOp {
   {
     return CheckMethodAccess(method, AccessSpecifier::AS_protected);
   }
+
+  bool IsPrivateMethod(TCppFunction_t method)
+  {
+    return CheckMethodAccess(method, AccessSpecifier::AS_private);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -569,6 +569,17 @@ namespace InterOp {
 
     return false;
   }
+
+  bool IsConstVariable(TCppScope_t var)
+  {
+    auto *D = (clang::Decl *) var;
+
+    if (auto *VD = llvm::dyn_cast_or_null<ValueDecl>(D)) {
+      return VD->getType().isConstQualified();
+    }
+
+    return false;
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -534,6 +534,21 @@ namespace InterOp {
 
     return 0;
   }
+
+  bool CheckVariableAccess(TCppScope_t var, AccessSpecifier AS)
+  {
+    auto *D = (Decl *) var;
+    if (auto *CXXMD = llvm::dyn_cast_or_null<DeclaratorDecl>(D)) {
+      return CXXMD->getAccess() == AS;
+    }
+
+    return false;
+  }
+
+  bool IsPublicVariable(TCppScope_t var)
+  {
+    return CheckVariableAccess(var, AccessSpecifier::AS_public);
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -247,6 +247,21 @@ namespace InterOp {
         return derived_CXXRD->isDerivedFrom(base_CXXRD);
     return false;
   }
+
+  std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass)
+  {
+    auto *D = (clang::Decl *) klass;
+
+    if (auto *CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
+      std::vector<TCppFunction_t> methods;
+      for (auto it = CXXRD->method_begin(), end = CXXRD->method_end();
+              it != end; it++) {
+        methods.push_back((TCppFunction_t) *it);
+      }
+      return methods;
+    }
+    return {};
+  }
 } // end namespace InterOp
 
 } // end namespace cling

--- a/unittests/libInterOp/CMakeLists.txt
+++ b/unittests/libInterOp/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
 add_cling_unittest(libInterOpTests
   ScopeReflectionTest.cpp
   FunctionReflectionTest.cpp
+  VariableReflectionTest.cpp
   )
 
 clang_target_link_libraries(libInterOpTests

--- a/unittests/libInterOp/CMakeLists.txt
+++ b/unittests/libInterOp/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_cling_unittest(libInterOpTests
   ScopeReflectionTest.cpp
+  FunctionReflectionTest.cpp
   )
 
 clang_target_link_libraries(libInterOpTests

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -288,3 +288,22 @@ TEST(FunctionReflectionTest, IsTemplatedFunction) {
   EXPECT_FALSE(InterOp::IsTemplatedFunction(SubDeclsC1[1]));
   EXPECT_TRUE(InterOp::IsTemplatedFunction(SubDeclsC1[2]));
 }
+
+TEST(FunctionReflectionTest, ExistsFunctionTemplate) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    template<typename T>
+    void f(T a) {}
+
+    class C {
+      template<typename T>
+      void f(T a) {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  auto *S = &Interp->getCI()->getSema();
+
+  EXPECT_TRUE(InterOp::ExistsFunctionTemplate(S, "f", 0));
+  EXPECT_TRUE(InterOp::ExistsFunctionTemplate(S, "f", Decls[1]));
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -263,3 +263,28 @@ TEST(FunctionReflectionTest, GetFunctionPrototype) {
   test_func_proto(Decls[12], true,
           "void N::f(int i, double d, long l = 0, char ch = 'a')"); // N::f
 }
+
+TEST(FunctionReflectionTest, IsTemplatedFunction) {
+  std::vector<Decl*> Decls, SubDeclsC1, SubDeclsC2;
+  std::string code = R"(
+    void f1(int a) {}
+
+    template<typename T>
+    void f2(T a) {}
+
+    class C1 {
+      void f1(int a) {}
+
+      template<typename T>
+      void f2(T a) {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[2], SubDeclsC1);
+
+  EXPECT_FALSE(InterOp::IsTemplatedFunction(Decls[0]));
+  EXPECT_TRUE(InterOp::IsTemplatedFunction(Decls[1]));
+  EXPECT_FALSE(InterOp::IsTemplatedFunction(SubDeclsC1[1]));
+  EXPECT_TRUE(InterOp::IsTemplatedFunction(SubDeclsC1[2]));
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -432,3 +432,19 @@ TEST(FunctionReflectionTest, IsDestructor) {
   EXPECT_FALSE(InterOp::IsDestructor(SubDecls[6]));
   EXPECT_FALSE(InterOp::IsDestructor(SubDecls[8]));
 }
+
+TEST(FunctionReflectionTest, IsStaticMethod) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+      void f1() {}
+      static void f2() {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_FALSE(InterOp::IsStaticMethod(SubDecls[1]));
+  EXPECT_TRUE(InterOp::IsStaticMethod(SubDecls[2]));
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -33,3 +33,50 @@ TEST(FunctionReflectionTest, GetClassMethods) {
   EXPECT_EQ(get_method_name(methods[3]), "A::f4");
   EXPECT_EQ(get_method_name(methods[4]), "A::f5");
 }
+
+TEST(FunctionReflectionTest, GetFunctionsUsingName) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    class A {
+    public:
+      int f1(int a, int b) { return a + b; }
+      int f1(int a) { return f1(a, 10); }
+      int f1() { return f1(10); }
+    private:
+      int f2() { return 0; }
+    protected:
+      int f3(int i) { return i; }
+    };
+
+    namespace N {
+      int f4(int a) { return a + 1; }
+      int f4() { return 0; }
+    }
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  // This lambda can take in the scope and the name of the function
+  // and check if GetFunctionsUsingName is returning a vector of functions
+  // with size equal to number_of_overloads
+  auto test_get_funcs_using_name = [&](InterOp::TCppScope_t scope,
+          const std::string name, std::size_t number_of_overloads) {
+    Sema *S = &Interp->getCI()->getSema();
+    auto Funcs = InterOp::GetFunctionsUsingName(S, scope, name);
+
+    // Check if the number of functions returned is equal to the
+    // number_of_overloads given by the user
+    EXPECT_TRUE(Funcs.size() == number_of_overloads);
+    for (auto *F : Funcs) {
+      // Check if the fully scoped name of the function matches its
+      // expected fully scoped name
+      EXPECT_EQ(InterOp::GetCompleteName(F),
+              InterOp::GetCompleteName(scope) + "::" + name);
+    }
+  };
+
+  test_get_funcs_using_name(Decls[0], "f1", 3);
+  test_get_funcs_using_name(Decls[0], "f2", 1);
+  test_get_funcs_using_name(Decls[0], "f3", 1);
+  test_get_funcs_using_name(Decls[1], "f4", 2);
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -382,3 +382,28 @@ TEST(FunctionReflectionTest, IsPrivateMethod) {
   EXPECT_TRUE(InterOp::IsPrivateMethod(SubDecls[6]));
   EXPECT_FALSE(InterOp::IsPrivateMethod(SubDecls[8]));
 }
+
+TEST(FunctionReflectionTest, IsConstructor) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+    public:
+      C() {}
+      void pub_f() {}
+      ~C() {}
+    private:
+      void pri_f() {}
+    protected:
+      void pro_f() {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_TRUE(InterOp::IsConstructor(SubDecls[2]));
+  EXPECT_FALSE(InterOp::IsConstructor(SubDecls[3]));
+  EXPECT_FALSE(InterOp::IsConstructor(SubDecls[4]));
+  EXPECT_FALSE(InterOp::IsConstructor(SubDecls[6]));
+  EXPECT_FALSE(InterOp::IsConstructor(SubDecls[8]));
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -407,3 +407,28 @@ TEST(FunctionReflectionTest, IsConstructor) {
   EXPECT_FALSE(InterOp::IsConstructor(SubDecls[6]));
   EXPECT_FALSE(InterOp::IsConstructor(SubDecls[8]));
 }
+
+TEST(FunctionReflectionTest, IsDestructor) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+    public:
+      C() {}
+      void pub_f() {}
+      ~C() {}
+    private:
+      void pri_f() {}
+    protected:
+      void pro_f() {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_FALSE(InterOp::IsDestructor(SubDecls[2]));
+  EXPECT_FALSE(InterOp::IsDestructor(SubDecls[3]));
+  EXPECT_TRUE(InterOp::IsDestructor(SubDecls[4]));
+  EXPECT_FALSE(InterOp::IsDestructor(SubDecls[6]));
+  EXPECT_FALSE(InterOp::IsDestructor(SubDecls[8]));
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -80,3 +80,40 @@ TEST(FunctionReflectionTest, GetFunctionsUsingName) {
   test_get_funcs_using_name(Decls[0], "f3", 1);
   test_get_funcs_using_name(Decls[1], "f4", 2);
 }
+
+TEST(FunctionReflectionTest, GetFunctionReturnTypeAsString) {
+  std::vector<Decl*> Decls, SubDecls;
+  std::string code = R"(
+    namespace N { class C {}; }
+    enum Switch { OFF, ON };
+
+    class A {
+      A (int i) { i++; }
+      int f () { return 0; }
+    };
+
+
+    void f1() {}
+    double f2() { return 0.2; }
+    Switch f3() { return ON; }
+    N::C f4() { return N::C(); }
+    N::C *f5() { return new N::C(); }
+    const N::C f6() { return N::C(); }
+    volatile N::C f7() { return N::C(); }
+    const volatile N::C f8() { return N::C(); }
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[2], SubDecls);
+
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(Decls[3]), "void");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(Decls[4]), "double");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(Decls[5]), "enum Switch");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(Decls[6]), "N::C");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(Decls[7]), "N::C *");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(Decls[8]), "const N::C");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(Decls[9]), "volatile N::C");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(Decls[10]), "const volatile N::C");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(SubDecls[1]), "void");
+  EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(SubDecls[2]), "int");
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -307,3 +307,28 @@ TEST(FunctionReflectionTest, ExistsFunctionTemplate) {
   EXPECT_TRUE(InterOp::ExistsFunctionTemplate(S, "f", 0));
   EXPECT_TRUE(InterOp::ExistsFunctionTemplate(S, "f", Decls[1]));
 }
+
+TEST(FunctionReflectionTest, IsPublicMethod) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+    public:
+      C() {}
+      void pub_f() {}
+      ~C() {}
+    private:
+      void pri_f() {}
+    protected:
+      void pro_f() {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_TRUE(InterOp::IsPublicMethod(SubDecls[2]));
+  EXPECT_TRUE(InterOp::IsPublicMethod(SubDecls[3]));
+  EXPECT_TRUE(InterOp::IsPublicMethod(SubDecls[4]));
+  EXPECT_FALSE(InterOp::IsPublicMethod(SubDecls[6]));
+  EXPECT_FALSE(InterOp::IsPublicMethod(SubDecls[8]));
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -357,3 +357,28 @@ TEST(FunctionReflectionTest, IsProtectedMethod) {
   EXPECT_FALSE(InterOp::IsProtectedMethod(SubDecls[6]));
   EXPECT_TRUE(InterOp::IsProtectedMethod(SubDecls[8]));
 }
+
+TEST(FunctionReflectionTest, IsPrivateMethod) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+    public:
+      C() {}
+      void pub_f() {}
+      ~C() {}
+    private:
+      void pri_f() {}
+    protected:
+      void pro_f() {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_FALSE(InterOp::IsPrivateMethod(SubDecls[2]));
+  EXPECT_FALSE(InterOp::IsPrivateMethod(SubDecls[3]));
+  EXPECT_FALSE(InterOp::IsPrivateMethod(SubDecls[4]));
+  EXPECT_TRUE(InterOp::IsPrivateMethod(SubDecls[6]));
+  EXPECT_FALSE(InterOp::IsPrivateMethod(SubDecls[8]));
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -117,3 +117,19 @@ TEST(FunctionReflectionTest, GetFunctionReturnTypeAsString) {
   EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(SubDecls[1]), "void");
   EXPECT_EQ(InterOp::GetFunctionReturnTypeAsString(SubDecls[2]), "int");
 }
+
+TEST(FunctionReflectionTest, GetFunctionNumArgs) {
+  std::vector<Decl*> Decls, SubDecls;
+  std::string code = R"(
+    void f1() {}
+    void f2(int i, double d, long l, char ch) {}
+    void f3(int i, double d, long l = 0, char ch = 'a') {}
+    void f4(int i = 0, double d = 0.0, long l = 0, char ch = 'a') {}
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  EXPECT_EQ(InterOp::GetFunctionNumArgs(Decls[0]), (size_t) 0);
+  EXPECT_EQ(InterOp::GetFunctionNumArgs(Decls[1]), (size_t) 4);
+  EXPECT_EQ(InterOp::GetFunctionNumArgs(Decls[2]), (size_t) 4);
+  EXPECT_EQ(InterOp::GetFunctionNumArgs(Decls[3]), (size_t) 4);
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -332,3 +332,28 @@ TEST(FunctionReflectionTest, IsPublicMethod) {
   EXPECT_FALSE(InterOp::IsPublicMethod(SubDecls[6]));
   EXPECT_FALSE(InterOp::IsPublicMethod(SubDecls[8]));
 }
+
+TEST(FunctionReflectionTest, IsProtectedMethod) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+    public:
+      C() {}
+      void pub_f() {}
+      ~C() {}
+    private:
+      void pri_f() {}
+    protected:
+      void pro_f() {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_FALSE(InterOp::IsProtectedMethod(SubDecls[2]));
+  EXPECT_FALSE(InterOp::IsProtectedMethod(SubDecls[3]));
+  EXPECT_FALSE(InterOp::IsProtectedMethod(SubDecls[4]));
+  EXPECT_FALSE(InterOp::IsProtectedMethod(SubDecls[6]));
+  EXPECT_TRUE(InterOp::IsProtectedMethod(SubDecls[8]));
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -133,3 +133,19 @@ TEST(FunctionReflectionTest, GetFunctionNumArgs) {
   EXPECT_EQ(InterOp::GetFunctionNumArgs(Decls[2]), (size_t) 4);
   EXPECT_EQ(InterOp::GetFunctionNumArgs(Decls[3]), (size_t) 4);
 }
+
+TEST(FunctionReflectionTest, GetFunctionRequiredArgs) {
+  std::vector<Decl*> Decls, SubDecls;
+  std::string code = R"(
+    void f1() {}
+    void f2(int i, double d, long l, char ch) {}
+    void f3(int i, double d, long l = 0, char ch = 'a') {}
+    void f4(int i = 0, double d = 0.0, long l = 0, char ch = 'a') {}
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  EXPECT_EQ(InterOp::GetFunctionRequiredArgs(Decls[0]), (size_t) 0);
+  EXPECT_EQ(InterOp::GetFunctionRequiredArgs(Decls[1]), (size_t) 4);
+  EXPECT_EQ(InterOp::GetFunctionRequiredArgs(Decls[2]), (size_t) 2);
+  EXPECT_EQ(InterOp::GetFunctionRequiredArgs(Decls[3]), (size_t) 0);
+}

--- a/unittests/libInterOp/FunctionReflectionTest.cpp
+++ b/unittests/libInterOp/FunctionReflectionTest.cpp
@@ -1,0 +1,35 @@
+#include "Utils.h"
+
+#include "cling/Interpreter/InterOp.h"
+
+#include "gtest/gtest.h"
+
+
+TEST(FunctionReflectionTest, GetClassMethods) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    class A {
+    public:
+      int f1(int a, int b) { return a + b; }
+      const A *f2() const { return this; }
+    private:
+      int f3() { return 0; }
+      void f4() {}
+    protected:
+      int f5(int i) { return i; }
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  auto methods = InterOp::GetClassMethods(Decls[0]);
+
+  auto get_method_name = [](InterOp::TCppFunction_t method) {
+    return InterOp::GetCompleteName(method);
+  };
+
+  EXPECT_EQ(get_method_name(methods[0]), "A::f1");
+  EXPECT_EQ(get_method_name(methods[1]), "A::f2");
+  EXPECT_EQ(get_method_name(methods[2]), "A::f3");
+  EXPECT_EQ(get_method_name(methods[3]), "A::f4");
+  EXPECT_EQ(get_method_name(methods[4]), "A::f5");
+}

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -292,3 +292,10 @@ TEST(ScopeReflectionTest, GetUsingNamespaces) {
   EXPECT_EQ(InterOp::GetName(usingNamespaces[1]), "std");
   EXPECT_EQ(InterOp::GetName(usingNamespaces[2]), "abc");
 }
+
+TEST(ScopeReflectionTest, GetGlobalScope) {
+  Interp = createInterpreter();
+  Sema *S = &Interp->getCI()->getSema();
+
+  EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetGlobalScope(S)), "");
+}

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -433,3 +433,26 @@ TEST(ScopeReflectionTest, GetScopeFromType) {
   EXPECT_EQ(InterOp::GetScopeFromType(&QT3),
           (cling::InterOp::TCppScope_t) 0);
 }
+
+TEST(ScopeReflectionTest, GetBaseClass) {
+  std::vector<Decl *> Decls;
+  std::string code = R"(
+    class A {};
+    class B : virtual public A {};
+    class C : virtual public A {};
+    class D : public B, public C {};
+    class E : public D {};
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  auto get_base_class_name = [](Decl *D, int i) {
+      return InterOp::GetCompleteName(InterOp::GetBaseClass(D, i));
+  };
+
+  EXPECT_EQ(get_base_class_name(Decls[1], 0), "A");
+  EXPECT_EQ(get_base_class_name(Decls[2], 0), "A");
+  EXPECT_EQ(get_base_class_name(Decls[3], 0), "B");
+  EXPECT_EQ(get_base_class_name(Decls[3], 1), "C");
+  EXPECT_EQ(get_base_class_name(Decls[4], 0), "D");
+}

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -73,6 +73,8 @@ static void GetAllTopLevelDecls(const std::string& code, std::vector<Decl*>& Dec
 }
 
 static void GetAllSubDecls(Decl *D, std::vector<Decl*>& SubDecls) {
+  if (!llvm::isa_and_nonnull<DeclContext>(D))
+    return;
   DeclContext *DC = Decl::castToDeclContext(D);
   for (auto DCI = DC->decls_begin(), E = DC->decls_end(); DCI != E; ++DCI) {
     SubDecls.push_back(*DCI);

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -406,3 +406,30 @@ TEST(ScopeReflectionTest, GetParentScope) {
   EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetParentScope(en_A)), "N1::N2::C::E");
   EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetParentScope(en_B)), "N1::N2::C::E");
 }
+
+TEST(ScopeReflectionTest, GetScopeFromType) {
+  std::vector<Decl *> Decls;
+  std::string code = R"(
+    namespace N {
+    class C {};
+    struct S {};
+    }
+
+    N::C c;
+
+    N::S s;
+
+    int i;
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+  QualType QT1 = llvm::dyn_cast<VarDecl>(Decls[1])->getType();
+  QualType QT2 = llvm::dyn_cast<VarDecl>(Decls[2])->getType();
+  QualType QT3 = llvm::dyn_cast<VarDecl>(Decls[3])->getType();
+  EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetScopeFromType(&QT1)),
+          "N::C");
+  EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetScopeFromType(&QT2)),
+          "N::S");
+  EXPECT_EQ(InterOp::GetScopeFromType(&QT3),
+          (cling::InterOp::TCppScope_t) 0);
+}

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -321,3 +321,23 @@ TEST(ScopeReflectionTest, GetScope) {
   EXPECT_EQ(InterOp::GetCompleteName(ns_N), "N");
   EXPECT_EQ(InterOp::GetCompleteName(cl_C), "N::C");
 }
+
+TEST(ScopeReflectionTest, GetScopefromCompleteName) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(namespace N1 {
+                        namespace N2 {
+                          class C {
+                            struct S {};
+                          };
+                        }
+                        }
+                       )";
+
+  Interp = createInterpreter();
+  Interp->declare(code);
+  Sema *S = &Interp->getCI()->getSema();
+  EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetScopeFromCompleteName(S, "N1")), "N1");
+  EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetScopeFromCompleteName(S, "N1::N2")), "N1::N2");
+  EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetScopeFromCompleteName(S, "N1::N2::C")), "N1::N2::C");
+  EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetScopeFromCompleteName(S, "N1::N2::C::S")), "N1::N2::C::S");
+}

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -456,3 +456,46 @@ TEST(ScopeReflectionTest, GetBaseClass) {
   EXPECT_EQ(get_base_class_name(Decls[3], 1), "C");
   EXPECT_EQ(get_base_class_name(Decls[4], 0), "D");
 }
+
+TEST(ScopeReflectionTest, IsSubclass) {
+  std::vector<Decl *> Decls;
+  std::string code = R"(
+    class A {};
+    class B : virtual public A {};
+    class C : virtual public A {};
+    class D : public B, public C {};
+    class E : public D {};
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  auto check_subclass = [](Decl *derived_D, Decl *base_D) {
+      return InterOp::IsSubclass(derived_D, base_D);
+  };
+
+  EXPECT_TRUE(check_subclass(Decls[0], Decls[0]));
+  EXPECT_TRUE(check_subclass(Decls[1], Decls[0]));
+  EXPECT_TRUE(check_subclass(Decls[2], Decls[0]));
+  EXPECT_TRUE(check_subclass(Decls[3], Decls[0]));
+  EXPECT_TRUE(check_subclass(Decls[4], Decls[0]));
+  EXPECT_FALSE(check_subclass(Decls[0], Decls[1]));
+  EXPECT_TRUE(check_subclass(Decls[1], Decls[1]));
+  EXPECT_FALSE(check_subclass(Decls[2], Decls[1]));
+  EXPECT_TRUE(check_subclass(Decls[3], Decls[1]));
+  EXPECT_TRUE(check_subclass(Decls[4], Decls[1]));
+  EXPECT_FALSE(check_subclass(Decls[0], Decls[2]));
+  EXPECT_FALSE(check_subclass(Decls[1], Decls[2]));
+  EXPECT_TRUE(check_subclass(Decls[2], Decls[2]));
+  EXPECT_TRUE(check_subclass(Decls[3], Decls[2]));
+  EXPECT_TRUE(check_subclass(Decls[4], Decls[2]));
+  EXPECT_FALSE(check_subclass(Decls[0], Decls[3]));
+  EXPECT_FALSE(check_subclass(Decls[1], Decls[3]));
+  EXPECT_FALSE(check_subclass(Decls[2], Decls[3]));
+  EXPECT_TRUE(check_subclass(Decls[3], Decls[3]));
+  EXPECT_TRUE(check_subclass(Decls[4], Decls[3]));
+  EXPECT_FALSE(check_subclass(Decls[0], Decls[4]));
+  EXPECT_FALSE(check_subclass(Decls[1], Decls[4]));
+  EXPECT_FALSE(check_subclass(Decls[2], Decls[4]));
+  EXPECT_FALSE(check_subclass(Decls[3], Decls[4]));
+  EXPECT_TRUE(check_subclass(Decls[4], Decls[4]));
+}

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -247,6 +247,26 @@ TEST(ScopeReflectionTest, GetName) {
   EXPECT_EQ(InterOp::GetName(Decls[7]), "Size16");
 }
 
+TEST(ScopeReflectionTest, GetCompleteName) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(namespace N {
+                        class C {
+                          int i;
+                          enum E { A, B };
+                        };
+                        }
+                       )";
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], Decls);
+  GetAllSubDecls(Decls[1], Decls);
+
+  EXPECT_EQ(InterOp::GetCompleteName(0), "<unnamed>");
+  EXPECT_EQ(InterOp::GetCompleteName(Decls[0]), "N");
+  EXPECT_EQ(InterOp::GetCompleteName(Decls[1]), "N::C");
+  EXPECT_EQ(InterOp::GetCompleteName(Decls[3]), "N::C::i");
+  EXPECT_EQ(InterOp::GetCompleteName(Decls[4]), "N::C::E");
+}
+
 TEST(ScopeReflectionTest, GetUsingNamespaces) {
   std::vector<Decl *> Decls;
   std::string code = R"(

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -299,3 +299,25 @@ TEST(ScopeReflectionTest, GetGlobalScope) {
 
   EXPECT_EQ(InterOp::GetCompleteName(InterOp::GetGlobalScope(S)), "");
 }
+
+TEST(ScopeReflectionTest, GetScope) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(namespace N {
+                        class C {
+                          int i;
+                          enum E { A, B };
+                        };
+                        }
+                       )";
+
+  Interp = createInterpreter();
+  Interp->declare(code);
+  Sema *S = &Interp->getCI()->getSema();
+  cling::InterOp::TCppScope_t tu = InterOp::GetScope(S, "", 0);
+  cling::InterOp::TCppScope_t ns_N = InterOp::GetScope(S, "N", 0);
+  cling::InterOp::TCppScope_t cl_C = InterOp::GetScope(S, "C", ns_N);
+
+  EXPECT_EQ(InterOp::GetCompleteName(tu), "");
+  EXPECT_EQ(InterOp::GetCompleteName(ns_N), "N");
+  EXPECT_EQ(InterOp::GetCompleteName(cl_C), "N::C");
+}

--- a/unittests/libInterOp/ScopeReflectionTest.cpp
+++ b/unittests/libInterOp/ScopeReflectionTest.cpp
@@ -1,85 +1,8 @@
+#include "Utils.h"
 
-#include "cling/Interpreter/Interpreter.h"
-#include "cling/Interpreter/Transaction.h"
 #include "cling/Interpreter/InterOp.h"
 
-#include "clang/Config/config.h"
-#include "clang/AST/Decl.h"
-#include "clang/AST/DeclCXX.h"
-#include "clang/Basic/Version.h"
-#include "clang/Frontend/CompilerInstance.h"
-#include "clang/Sema/Sema.h"
-
-#include "llvm/ADT/StringRef.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Path.h"
-
 #include "gtest/gtest.h"
-
-using namespace cling;
-using namespace clang;
-using namespace llvm;
-
-// This function isn't referenced outside its translation unit, but it
-// can't use the "static" keyword because its address is used for
-// GetMainExecutable (since some platforms don't support taking the
-// address of main, and some platforms can't implement GetMainExecutable
-// without being given the address of a function in the main executable).
-std::string GetExecutablePath(const char *Argv0, void *MainAddr) {
-  return llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
-}
-
-static std::string MakeResourcesPath() {
-  // Dir is bin/ or lib/, depending on where BinaryPath is.
-  void *MainAddr = (void *)(intptr_t)GetExecutablePath;
-  std::string BinaryPath = GetExecutablePath(/*Argv0=*/nullptr, MainAddr);
-
-  // build/tools/clang/unittests/Interpreter/Executable -> build/
-  llvm::StringRef Dir = llvm::sys::path::parent_path(BinaryPath);
-
-  Dir = llvm::sys::path::parent_path(Dir);
-  Dir = llvm::sys::path::parent_path(Dir);
-  Dir = llvm::sys::path::parent_path(Dir);
-  Dir = llvm::sys::path::parent_path(Dir);
-  //Dir = llvm::sys::path::parent_path(Dir);
-  llvm::SmallString<128> P(Dir);
-  llvm::sys::path::append(P, llvm::Twine("lib") + CLANG_LIBDIR_SUFFIX, "clang",
-                          CLANG_VERSION_STRING);
-
-  return std::string(P.str());
-}
-
-static std::unique_ptr<Interpreter> createInterpreter() {
-  std::string MainExecutableName =
-    llvm::sys::fs::getMainExecutable(nullptr, nullptr);
-  std::string ResourceDir = MakeResourcesPath();
-  std::vector<const char *> ClingArgv = {"-resource-dir", ResourceDir.c_str()};
-  ClingArgv.insert(ClingArgv.begin(), MainExecutableName.c_str());
-  return llvm::make_unique<Interpreter>(ClingArgv.size(), &ClingArgv[0]);
-}
-
-std::unique_ptr<Interpreter> Interp;
-
-static void GetAllTopLevelDecls(const std::string& code, std::vector<Decl*>& Decls) {
-  Interp = createInterpreter();
-  Transaction *T = nullptr;
-  Interp->declare(code, &T);
-  for (auto DCI = T->decls_begin(), E = T->decls_end(); DCI != E; ++DCI) {
-    if (DCI->m_Call != Transaction::kCCIHandleTopLevelDecl)
-      continue;
-    assert(DCI->m_DGR.isSingleDecl());
-    Decls.push_back(DCI->m_DGR.getSingleDecl());
-  }
-}
-
-static void GetAllSubDecls(Decl *D, std::vector<Decl*>& SubDecls) {
-  if (!llvm::isa_and_nonnull<DeclContext>(D))
-    return;
-  DeclContext *DC = Decl::castToDeclContext(D);
-  for (auto DCI = DC->decls_begin(), E = DC->decls_end(); DCI != E; ++DCI) {
-    SubDecls.push_back(*DCI);
-  }
-}
 
 // Check that the CharInfo table has been constructed reasonably.
 TEST(ScopeReflectionTest, IsNamespace) {

--- a/unittests/libInterOp/Utils.h
+++ b/unittests/libInterOp/Utils.h
@@ -1,0 +1,84 @@
+#ifndef CLING_UNITTESTS_LIBINTEROP_UTILS_H
+#define CLING_UNITTESTS_LIBINTEROP_UTILS_H
+
+#include "cling/Interpreter/Interpreter.h"
+#include "cling/Interpreter/Transaction.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+
+#include "clang/Config/config.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/Basic/Version.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Sema/Sema.h"
+
+using namespace cling;
+using namespace clang;
+using namespace llvm;
+
+// This function isn't referenced outside its translation unit, but it
+// can't use the "static" keyword because its address is used for
+// GetMainExecutable (since some platforms don't support taking the
+// address of main, and some platforms can't implement GetMainExecutable
+// without being given the address of a function in the main executable).
+static std::string GetExecutablePath(const char *Argv0, void *MainAddr) {
+  return sys::fs::getMainExecutable(Argv0, MainAddr);
+}
+
+static std::string MakeResourcesPath() {
+  // Dir is bin/ or lib/, depending on where BinaryPath is.
+  void *MainAddr = (void *)(intptr_t)GetExecutablePath;
+  std::string BinaryPath = GetExecutablePath(/*Argv0=*/nullptr, MainAddr);
+
+  // build/tools/clang/unittests/Interpreter/Executable -> build/
+  StringRef Dir = sys::path::parent_path(BinaryPath);
+
+  Dir = sys::path::parent_path(Dir);
+  Dir = sys::path::parent_path(Dir);
+  Dir = sys::path::parent_path(Dir);
+  Dir = sys::path::parent_path(Dir);
+  //Dir = sys::path::parent_path(Dir);
+  SmallString<128> P(Dir);
+  sys::path::append(P, Twine("lib") + CLANG_LIBDIR_SUFFIX, "clang",
+                          CLANG_VERSION_STRING);
+
+  return std::string(P.str());
+}
+
+static std::unique_ptr<Interpreter> createInterpreter() {
+  std::string MainExecutableName =
+    sys::fs::getMainExecutable(nullptr, nullptr);
+  std::string ResourceDir = MakeResourcesPath();
+  std::vector<const char *> ClingArgv = {"-resource-dir", ResourceDir.c_str()};
+  ClingArgv.insert(ClingArgv.begin(), MainExecutableName.c_str());
+  return make_unique<Interpreter>(ClingArgv.size(), &ClingArgv[0]);
+}
+
+static std::unique_ptr<Interpreter> Interp;
+
+static void GetAllTopLevelDecls(const std::string& code, std::vector<Decl*>& Decls) {
+  Interp = createInterpreter();
+  Transaction *T = nullptr;
+  Interp->declare(code, &T);
+  for (auto DCI = T->decls_begin(), E = T->decls_end(); DCI != E; ++DCI) {
+    if (DCI->m_Call != Transaction::kCCIHandleTopLevelDecl)
+      continue;
+    assert(DCI->m_DGR.isSingleDecl());
+    Decls.push_back(DCI->m_DGR.getSingleDecl());
+  }
+}
+
+static void GetAllSubDecls(Decl *D, std::vector<Decl*>& SubDecls) {
+  if (!isa_and_nonnull<DeclContext>(D))
+    return;
+  DeclContext *DC = Decl::castToDeclContext(D);
+  for (auto DCI = DC->decls_begin(), E = DC->decls_end(); DCI != E; ++DCI) {
+    SubDecls.push_back(*DCI);
+  }
+}
+
+#endif // CLING_UNITTESTS_LIBINTEROP_UTILS_H
+

--- a/unittests/libInterOp/VariableReflectionTest.cpp
+++ b/unittests/libInterOp/VariableReflectionTest.cpp
@@ -56,3 +56,41 @@ TEST(VariableReflectionTest, GetVariableTypeAsString) {
   EXPECT_EQ(InterOp::GetVariableTypeAsString(Decls[6]), "E<int>");
   EXPECT_EQ(InterOp::GetVariableTypeAsString(Decls[7]), "E<int> *");
 }
+
+TEST(VariableReflectionTest, GetVariableOffset) {
+  std::vector<Decl *> Decls;
+  std::string code = R"(
+    int a;
+    class C {
+    public:
+      int a;
+      double b;
+      int *c;
+      int d;
+    };
+    )";
+
+  class {
+  public:
+    int a;
+    double b;
+    int *c;
+    int d;
+  } c;
+
+
+  GetAllTopLevelDecls(code, Decls);
+  auto datamembers = InterOp::GetDatamembers(Decls[1]);
+
+  EXPECT_FALSE(InterOp::GetVariableOffset(Interp.get(), Decls[0])
+          == (intptr_t) 0);
+
+  EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[0]),
+          0);
+  EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[1]),
+          ((unsigned long) &(c.b)) - ((unsigned long) &(c.a)));
+  EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[2]),
+          ((unsigned long) &(c.c)) - ((unsigned long) &(c.a)));
+  EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[3]),
+          ((unsigned long) &(c.d)) - ((unsigned long) &(c.a)));
+}

--- a/unittests/libInterOp/VariableReflectionTest.cpp
+++ b/unittests/libInterOp/VariableReflectionTest.cpp
@@ -157,3 +157,19 @@ TEST(VariableReflectionTest, IsPrivateVariable) {
   EXPECT_TRUE(InterOp::IsPrivateVariable(SubDecls[4]));
   EXPECT_FALSE(InterOp::IsPrivateVariable(SubDecls[6]));
 }
+
+TEST(VariableReflectionTest, IsStaticVariable) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code =  R"(
+    class C {
+      int a;
+      static int b;
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_FALSE(InterOp::IsStaticVariable(SubDecls[1]));
+  EXPECT_TRUE(InterOp::IsStaticVariable(SubDecls[2]));
+}

--- a/unittests/libInterOp/VariableReflectionTest.cpp
+++ b/unittests/libInterOp/VariableReflectionTest.cpp
@@ -30,3 +30,29 @@ TEST(VariableReflectionTest, GetDatamembers) {
   EXPECT_EQ(InterOp::GetCompleteName(datamembers[2]), "C::e");
   EXPECT_EQ(datamembers.size(), 3);
 }
+
+TEST(VariableReflectionTest, GetVariableTypeAsString) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    class C {};
+
+    template<typename T>
+    class E {};
+
+    int a;
+    char b;
+    C c;
+    C *d;
+    E<int> e;
+    E<int> *f;
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  EXPECT_EQ(InterOp::GetVariableTypeAsString(Decls[2]), "int");
+  EXPECT_EQ(InterOp::GetVariableTypeAsString(Decls[3]), "char");
+  EXPECT_EQ(InterOp::GetVariableTypeAsString(Decls[4]), "class C");
+  EXPECT_EQ(InterOp::GetVariableTypeAsString(Decls[5]), "class C *");
+  EXPECT_EQ(InterOp::GetVariableTypeAsString(Decls[6]), "E<int>");
+  EXPECT_EQ(InterOp::GetVariableTypeAsString(Decls[7]), "E<int> *");
+}

--- a/unittests/libInterOp/VariableReflectionTest.cpp
+++ b/unittests/libInterOp/VariableReflectionTest.cpp
@@ -173,3 +173,19 @@ TEST(VariableReflectionTest, IsStaticVariable) {
   EXPECT_FALSE(InterOp::IsStaticVariable(SubDecls[1]));
   EXPECT_TRUE(InterOp::IsStaticVariable(SubDecls[2]));
 }
+
+TEST(VariableReflectionTest, IsConstVariable) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code =  R"(
+    class C {
+      int a;
+      const int b = 2;
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_FALSE(InterOp::IsConstVariable(SubDecls[1]));
+  EXPECT_TRUE(InterOp::IsConstVariable(SubDecls[2]));
+}

--- a/unittests/libInterOp/VariableReflectionTest.cpp
+++ b/unittests/libInterOp/VariableReflectionTest.cpp
@@ -136,3 +136,24 @@ TEST(VariableReflectionTest, IsProtectedVariable) {
   EXPECT_FALSE(InterOp::IsProtectedVariable(SubDecls[4]));
   EXPECT_TRUE(InterOp::IsProtectedVariable(SubDecls[6]));
 }
+
+TEST(VariableReflectionTest, IsPrivateVariable) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+    public:
+      int a;
+    private:
+      int b;
+    protected:
+      int c;
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_FALSE(InterOp::IsPrivateVariable(SubDecls[2]));
+  EXPECT_TRUE(InterOp::IsPrivateVariable(SubDecls[4]));
+  EXPECT_FALSE(InterOp::IsPrivateVariable(SubDecls[6]));
+}

--- a/unittests/libInterOp/VariableReflectionTest.cpp
+++ b/unittests/libInterOp/VariableReflectionTest.cpp
@@ -94,3 +94,24 @@ TEST(VariableReflectionTest, GetVariableOffset) {
   EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[3]),
           ((unsigned long) &(c.d)) - ((unsigned long) &(c.a)));
 }
+
+TEST(VariableReflectionTest, IsPublicVariable) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+    public:
+      int a;
+    private:
+      int b;
+    protected:
+      int c;
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_TRUE(InterOp::IsPublicVariable(SubDecls[2]));
+  EXPECT_FALSE(InterOp::IsPublicVariable(SubDecls[4]));
+  EXPECT_FALSE(InterOp::IsPublicVariable(SubDecls[6]));
+}

--- a/unittests/libInterOp/VariableReflectionTest.cpp
+++ b/unittests/libInterOp/VariableReflectionTest.cpp
@@ -115,3 +115,24 @@ TEST(VariableReflectionTest, IsPublicVariable) {
   EXPECT_FALSE(InterOp::IsPublicVariable(SubDecls[4]));
   EXPECT_FALSE(InterOp::IsPublicVariable(SubDecls[6]));
 }
+
+TEST(VariableReflectionTest, IsProtectedVariable) {
+  std::vector<Decl *> Decls, SubDecls;
+  std::string code = R"(
+    class C {
+    public:
+      int a;
+    private:
+      int b;
+    protected:
+      int c;
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  EXPECT_FALSE(InterOp::IsProtectedVariable(SubDecls[2]));
+  EXPECT_FALSE(InterOp::IsProtectedVariable(SubDecls[4]));
+  EXPECT_TRUE(InterOp::IsProtectedVariable(SubDecls[6]));
+}

--- a/unittests/libInterOp/VariableReflectionTest.cpp
+++ b/unittests/libInterOp/VariableReflectionTest.cpp
@@ -1,0 +1,32 @@
+
+#include "Utils.h"
+
+#include "cling/Interpreter/InterOp.h"
+
+#include "gtest/gtest.h"
+
+
+TEST(VariableReflectionTest, GetDatamembers) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    class C {
+    public:
+      int a;
+      static int b;
+    private:
+      int c;
+      static int d;
+    protected:
+      int e;
+      static int f;
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  auto datamembers = InterOp::GetDatamembers(Decls[0]);
+
+  EXPECT_EQ(InterOp::GetCompleteName(datamembers[0]), "C::a");
+  EXPECT_EQ(InterOp::GetCompleteName(datamembers[1]), "C::c");
+  EXPECT_EQ(InterOp::GetCompleteName(datamembers[2]), "C::e");
+  EXPECT_EQ(datamembers.size(), 3);
+}


### PR DESCRIPTION
Added:
- `GetCompleteName`
- `GetGlobalScope`
- `GetScope`
- `GetScopeFromCompleteName`
- `GetNamed`
- `GetParentScope`
- `GetScopeFromType`
- `GetBaseScope`
- `IsSubClass`
- `GetClassMethods`
- `GetMethodsFromName`
- `GetMethodReturnTypeAsString`
- `GetMethodNumArgs`
- `GetMethodReqArgs`

Also:
- Fixed `InterOp.h` as `vector` header was missing
- Fixed `GetAllSubDecls` by adding `DeclContext`
- Moved utility functions to `Utils.h`